### PR TITLE
PLATOPS-1619: Upgrade to Play 2.5.19

### DIFF
--- a/project/KenshooMonitoring.scala
+++ b/project/KenshooMonitoring.scala
@@ -17,22 +17,20 @@ import sbt.Keys._
 import sbt._
 import uk.gov.hmrc.DefaultBuildSettings._
 import uk.gov.hmrc.PublishingSettings._
-import uk.gov.hmrc.versioning.SbtGitVersioning
 
 object KenshooMonitoringBuild extends Build {
-  import uk.gov.hmrc.SbtAutoBuildPlugin
-  import uk.gov.hmrc.SbtArtifactory
+  import uk.gov.hmrc.SbtArtifactory.autoImport.makePublicallyAvailableOnBintray
+  import uk.gov.hmrc.{SbtArtifactory, SbtAutoBuildPlugin}
   import uk.gov.hmrc.versioning.SbtGitVersioning
   import uk.gov.hmrc.versioning.SbtGitVersioning.autoImport.majorVersion
-  import uk.gov.hmrc.SbtArtifactory.autoImport.makePublicallyAvailableOnBintray
 
   val appDependencies = Seq(
-    "uk.gov.hmrc" %% "bootstrap-play-25" % "3.15.0",
+    "uk.gov.hmrc" %% "bootstrap-play-25" % "4.1.0",
     "de.threedimensions" %% "metrics-play" % "2.5.13",
 
     "org.scalatest" %% "scalatest" % "3.0.5" % "test",
     "org.mockito" % "mockito-core" % "2.23.4" % "test",
-    "uk.gov.hmrc" %% "hmrctest" % "3.2.0" % "test"
+    "uk.gov.hmrc" %% "hmrctest" % "3.3.0" % "test"
   )
 
   lazy val scoverageSettings = {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.13.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.15.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.12")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.19")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 


### PR DESCRIPTION
We have had to update all the libraries on the platform to use Play 2.5.19 to address a security vulnerability with a version of logback that is included in play (< 2.5.14) which is fixed in play 2.5.19.