### PR TITLE
PLATOPS-1619, PLATOPS-1795: Upgrade bootstrap-play-25 to 4.2.0

### DIFF
--- a/project/KenshooMonitoring.scala
+++ b/project/KenshooMonitoring.scala
@@ -25,7 +25,7 @@ object KenshooMonitoringBuild extends Build {
   import uk.gov.hmrc.versioning.SbtGitVersioning.autoImport.majorVersion
 
   val appDependencies = Seq(
-    "uk.gov.hmrc" %% "bootstrap-play-25" % "4.1.0",
+    "uk.gov.hmrc" %% "bootstrap-play-25" % "4.2.0",
     "de.threedimensions" %% "metrics-play" % "2.5.13",
 
     "org.scalatest" %% "scalatest" % "3.0.5" % "test",


### PR DESCRIPTION
bootstrap-play-25 4.2.0 fixes the failed deployments for services that attempted to upgrade to Play 2.5.19.